### PR TITLE
[WSL-336] Implementing Stdin redirection

### DIFF
--- a/examples/demo.go
+++ b/examples/demo.go
@@ -28,12 +28,10 @@ func main() {
 
 	// Launching async command
 	process1 := distro.Command(context.Background(), `sleep 3 && cat goodmorning.txt`)
-	process1.Stdin = 0 // (nullptr) TODO: Make this more Go-like with readers and writers
 	process1.Start()
 
 	// Launching async command
 	process2 := distro.Command(context.Background(), `echo "Hello, world from WSL!" > "goodmorning.txt"`)
-	process2.Stdin = 0 // (nullptr) TODO: Make this more Go-like with readers and writers
 	process2.Run()
 
 	// Launching an interactive command (should fail as per config change)

--- a/exec_test.go
+++ b/exec_test.go
@@ -509,7 +509,7 @@ func TestCommandStdin(t *testing.T) {
 		closeBeforeWait bool // Set to true to close the pipe before execution of the Cmd is over
 		readFrom        int  // Where Cmd should read Stdin from
 	}{
-		"standard":         {},
+		"from pipe":        {},
 		"funny characters": {text: "Hello, \x00wsl!"},
 		"closing early":    {closeBeforeWait: true},
 		"using a buffer":   {readFrom: readFromBuffer},

--- a/exec_test.go
+++ b/exec_test.go
@@ -591,7 +591,7 @@ print("Your text was", v)
 			}
 
 			err = cmd.Wait()
-			require.NoError(t, err, "Unexpected error on comand wait")
+			require.NoError(t, err, "Unexpected error on command wait")
 
 			if tc.readFrom == readFromPipe {
 				err = stdin.(io.WriteCloser).Close() // nolint: forcetypeassert

--- a/exec_test.go
+++ b/exec_test.go
@@ -559,10 +559,11 @@ print("Your text was", v)
 			err = cmd.Start()
 			require.NoError(t, err, "Unexpected error calling (*Cmd).Start")
 
+			// We ignore the error because:
+			// - In the happy path (all checks pass) we'll have waited on the command already, so
+			//   this second wait is superfluous.
+			// - If a check fails, we don't really care about any subsequent errors like this one.
 			defer cmd.Wait() // nolint: errcheck
-			// We know it's going to fail in normal execution. It's here to close
-			// the process when a require check fails, at which point the test has
-			// failed already, hence no need to make more checks.
 
 			buffer := make([]byte, 1024)
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -498,7 +498,7 @@ func TestCommandStdin(t *testing.T) {
 	d := newTestDistro(t, jammyRootFs)
 
 	const (
-		readFromPipe int = iota + 1
+		readFromPipe int = iota
 		readFromBuffer
 	)
 
@@ -509,9 +509,9 @@ func TestCommandStdin(t *testing.T) {
 		closeBeforeWait bool // Set to true to close the pipe before execution of the Cmd is over
 		readFrom        int  // Where Cmd should read Stdin from
 	}{
-		"standard":         {text: "Hello, wsl!", readFrom: readFromPipe},
-		"funny characters": {text: "Hello, \x00\twsl!", readFrom: readFromPipe},
-		"closing early":    {text: "Hello, wsl!", closeBeforeWait: true, readFrom: readFromPipe},
+		"standard":         {text: "Hello, wsl!"},
+		"funny characters": {text: "Hello, \x00\twsl!"},
+		"closing early":    {text: "Hello, wsl!", closeBeforeWait: true},
 		"using a buffer":   {text: "Hello, wsl!", readFrom: readFromBuffer},
 	}
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -509,10 +509,10 @@ func TestCommandStdin(t *testing.T) {
 		closeBeforeWait bool // Set to true to close the pipe before execution of the Cmd is over
 		readFrom        int  // Where Cmd should read Stdin from
 	}{
-		"standard":         {text: "Hello, wsl!"},
-		"funny characters": {text: "Hello, \x00\twsl!"},
-		"closing early":    {text: "Hello, wsl!", closeBeforeWait: true},
-		"using a buffer":   {text: "Hello, wsl!", readFrom: readFromBuffer},
+		"standard":         {},
+		"funny characters": {text: "Hello, \x00wsl!"},
+		"closing early":    {closeBeforeWait: true},
+		"using a buffer":   {readFrom: readFromBuffer},
 	}
 
 	// Simple program to test stdin
@@ -526,6 +526,10 @@ print("Your text was", v)
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			if tc.text == "" {
+				tc.text = "Hello, wsl!"
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 			defer cancel()
 


### PR DESCRIPTION
Implements the following methods with the same API as `exec/exec.go` (and often the same implementation):
```go
var Cmd.Stdin io.Reader
func (c *Cmd) StdinPipe() (io.WriteCloser, error)
type closeOnce struct
func (c *closeOnce) Close() error
```