### PR TITLE
Fix a memory leak in GetConfiguration

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -4,7 +4,9 @@ package wsl
 
 import (
 	"syscall"
+	"unsafe"
 
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -28,3 +30,7 @@ const (
 type wBOOL = int     // Windows' BOOL
 type wULONG = uint32 // Windows' ULONG
 type char = byte     // Windows' CHAR (which is the same as C's char)
+
+func coTaskMemFree(p unsafe.Pointer) {
+	windows.CoTaskMemFree(p)
+}


### PR DESCRIPTION
From [the docs](https://learn.microsoft.com/en-us/windows/win32/api/wslapi/nf-wslapi-wslgetdistributionconfiguration):

> The caller is responsible for freeing each string in pDefaultEnvironmentVariablesArray (and the array itself) via CoTaskMemFree.