### PR TITLE
[WSL-335] Implementing Stdout  and Stderr redirection

### DIFF
--- a/.golangci-ci.yaml
+++ b/.golangci-ci.yaml
@@ -29,8 +29,7 @@ linters:
     ##- wrapcheck # To think properly about it
 
 run:
-  # Most of the time, it’s taking less than 20s, but some builders are slower, so takes 2m
-  timeout: 2m
+  timeout: 5m
 
 # Get all linter issues, even if duplicated
 issues:

--- a/exec.go
+++ b/exec.go
@@ -223,8 +223,8 @@ func (c *Cmd) Output() ([]byte, error) {
 
 	err := c.Run()
 	if err != nil && captureErr {
-		if ee, ok := err.(*ExitError); ok {
-			ee.Stderr = c.Stderr.(*prefixSuffixSaver).Bytes()
+		if ee, ok := err.(*ExitError); ok { // nolint: errorlint, forcetypeassert
+			ee.Stderr = c.Stderr.(*prefixSuffixSaver).Bytes() // nolint: errorlint, forcetypeassert
 		}
 	}
 	return stdout.Bytes(), err
@@ -403,7 +403,7 @@ func (c *Cmd) waitProcess() (uint32, error) {
 //
 // If the command fails to run or doesn't complete successfully, the error is of type *ExitError.
 //
-// Taken from exec/exec.go
+// Taken from exec/exec.go.
 func (c *Cmd) Run() error {
 	if err := c.Start(); err != nil {
 		return err
@@ -440,7 +440,7 @@ func (c *Cmd) kill() error {
 // and the last N bytes written to it. The Bytes() methods reconstructs
 // it with a pretty error message.
 //
-// Taken from exec/exec.go
+// Taken from exec/exec.go.
 type prefixSuffixSaver struct {
 	N         int // max size of prefix or suffix
 	prefix    []byte
@@ -482,7 +482,7 @@ func (w *prefixSuffixSaver) Write(p []byte) (n int, err error) {
 // fill appends up to len(p) bytes of p to *dst, such that *dst does not
 // grow larger than w.N. It returns the un-appended suffix of p.
 //
-// Taken from exec/exec.go
+// Taken from exec/exec.go.
 func (w *prefixSuffixSaver) fill(dst *[]byte, p []byte) (pRemain []byte) {
 	if remain := w.N - len(*dst); remain > 0 {
 		add := minInt(len(p), remain)
@@ -494,7 +494,7 @@ func (w *prefixSuffixSaver) fill(dst *[]byte, p []byte) (pRemain []byte) {
 
 // Bytes returns the contents of the buffer.
 //
-// Taken from exec/exec.go
+// Taken from exec/exec.go.
 func (w *prefixSuffixSaver) Bytes() []byte {
 	if w.suffix == nil {
 		return w.prefix
@@ -513,7 +513,7 @@ func (w *prefixSuffixSaver) Bytes() []byte {
 	return buf.Bytes()
 }
 
-// Taken from exec/exec.go
+// Taken from exec/exec.go.
 func minInt(a, b int) int {
 	if a < b {
 		return a

--- a/exec.go
+++ b/exec.go
@@ -230,6 +230,22 @@ func (c *Cmd) Output() ([]byte, error) {
 	return stdout.Bytes(), err
 }
 
+// CombinedOutput runs the command and returns its combined standard
+// output and standard error.
+func (c *Cmd) CombinedOutput() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("wsl: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, errors.New("wsl: Stderr already set")
+	}
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	err := c.Run()
+	return b.Bytes(), err
+}
+
 func (c *Cmd) stdin() error {
 	// TODO
 	return nil

--- a/exec.go
+++ b/exec.go
@@ -209,6 +209,8 @@ func (c *Cmd) Start() (err error) {
 // Output runs the command and returns its standard output.
 // Any returned error will usually be of type *ExitError.
 // If c.Stderr was nil, Output populates ExitError.Stderr.
+//
+// Taken from exec/exec.go.
 func (c *Cmd) Output() ([]byte, error) {
 	if c.Stdout != nil {
 		return nil, errors.New("wsl: Stdout already set")
@@ -305,6 +307,7 @@ func (c *Cmd) stdin() error {
 	return nil
 }
 
+// Based on exec/exec.go.
 func (c *Cmd) stdout() error {
 	w, e := c.writerDescriptor(c.Stdout)
 	if e == nil {
@@ -313,6 +316,7 @@ func (c *Cmd) stdout() error {
 	return e
 }
 
+// Based on exec/exec.go.
 func (c *Cmd) stderr() error {
 	// Case where Stdout and Stderr are the same
 	if c.Stderr != nil && interfaceEqual(c.Stdout, c.Stderr) {
@@ -329,6 +333,8 @@ func (c *Cmd) stderr() error {
 
 // interfaceEqual protects against panics from doing equality tests on
 // two interfaces with non-comparable underlying types.
+//
+// Taken from exec/exec.go.
 func interfaceEqual(a, b any) bool {
 	defer func() {
 		_ = recover()

--- a/exec.go
+++ b/exec.go
@@ -123,7 +123,7 @@ func (c *Cmd) Start() (err error) {
 
 	commandUTF16, err := syscall.UTF16PtrFromString(c.command)
 	if err != nil {
-		return fmt.Errorf("failed to convert command '%s' to UTF16", c.command)
+		return fmt.Errorf("failed to convert command %q to UTF16", c.command)
 	}
 
 	var useCwd wBOOL

--- a/exec.go
+++ b/exec.go
@@ -3,12 +3,15 @@ package wsl
 // This file contains utilities to launch commands into WSL distros.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/0xrawsec/golang-utils/log"
@@ -58,7 +61,8 @@ type Cmd struct {
 // ExitError represents a non-zero exit status from a WSL process.
 // Linux's exit errors range from 0 to 255, larger numbers correspond to Windows-side errors.
 type ExitError struct {
-	Code uint32
+	Code   uint32
+	Stderr []byte
 }
 
 func (m ExitError) Error() string {
@@ -200,6 +204,30 @@ func (c *Cmd) Start() (err error) {
 	}
 
 	return nil
+}
+
+// Output runs the command and returns its standard output.
+// Any returned error will usually be of type *ExitError.
+// If c.Stderr was nil, Output populates ExitError.Stderr.
+func (c *Cmd) Output() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("wsl: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	c.Stdout = &stdout
+
+	captureErr := c.Stderr == nil
+	if captureErr {
+		c.Stderr = &prefixSuffixSaver{N: 32 << 10}
+	}
+
+	err := c.Run()
+	if err != nil && captureErr {
+		if ee, ok := err.(*ExitError); ok {
+			ee.Stderr = c.Stderr.(*prefixSuffixSaver).Bytes()
+		}
+	}
+	return stdout.Bytes(), err
 }
 
 func (c *Cmd) stdin() error {
@@ -353,6 +381,13 @@ func (c *Cmd) waitProcess() (uint32, error) {
 		return WindowsError, fmt.Errorf("failed syscall to WaitForSingleObject, non-zero exit status %d", event)
 	}
 
+	// NOTE(brainman): It seems that sometimes process is not dead
+	// when WaitForSingleObject returns. But we do not know any
+	// other way to wait for it. Sleeping for a while seems to do
+	// the trick sometimes.
+	// See https://golang.org/issue/25965 for details.
+	time.Sleep(5 * time.Millisecond)
+
 	status, statusError := c.status()
 	ok := statusError == nil && status == 0
 
@@ -367,6 +402,8 @@ func (c *Cmd) waitProcess() (uint32, error) {
 // The returned error is nil if the command runs and exits with a zero exit status.
 //
 // If the command fails to run or doesn't complete successfully, the error is of type *ExitError.
+//
+// Taken from exec/exec.go
 func (c *Cmd) Run() error {
 	if err := c.Start(); err != nil {
 		return err
@@ -397,4 +434,89 @@ func (c *Cmd) kill() error {
 		c.exitStatus = &status
 	}
 	return syscall.TerminateProcess(c.handle, ActiveProcess)
+}
+
+// prefixSuffixSaver is an io.Writer which retains the first N bytes
+// and the last N bytes written to it. The Bytes() methods reconstructs
+// it with a pretty error message.
+//
+// Taken from exec/exec.go
+type prefixSuffixSaver struct {
+	N         int // max size of prefix or suffix
+	prefix    []byte
+	suffix    []byte // ring buffer once len(suffix) == N
+	suffixOff int    // offset to write into suffix
+	skipped   int64
+
+	// TODO(bradfitz): we could keep one large []byte and use part of it for
+	// the prefix, reserve space for the '... Omitting N bytes ...' message,
+	// then the ring buffer suffix, and just rearrange the ring buffer
+	// suffix when Bytes() is called, but it doesn't seem worth it for
+	// now just for error messages. It's only ~64KB anyway.
+}
+
+func (w *prefixSuffixSaver) Write(p []byte) (n int, err error) {
+	lenp := len(p)
+	p = w.fill(&w.prefix, p)
+
+	// Only keep the last w.N bytes of suffix data.
+	if overage := len(p) - w.N; overage > 0 {
+		p = p[overage:]
+		w.skipped += int64(overage)
+	}
+	p = w.fill(&w.suffix, p)
+
+	// w.suffix is full now if p is non-empty. Overwrite it in a circle.
+	for len(p) > 0 { // 0, 1, or 2 iterations.
+		n := copy(w.suffix[w.suffixOff:], p)
+		p = p[n:]
+		w.skipped += int64(n)
+		w.suffixOff += n
+		if w.suffixOff == w.N {
+			w.suffixOff = 0
+		}
+	}
+	return lenp, nil
+}
+
+// fill appends up to len(p) bytes of p to *dst, such that *dst does not
+// grow larger than w.N. It returns the un-appended suffix of p.
+//
+// Taken from exec/exec.go
+func (w *prefixSuffixSaver) fill(dst *[]byte, p []byte) (pRemain []byte) {
+	if remain := w.N - len(*dst); remain > 0 {
+		add := minInt(len(p), remain)
+		*dst = append(*dst, p[:add]...)
+		p = p[add:]
+	}
+	return p
+}
+
+// Bytes returns the contents of the buffer.
+//
+// Taken from exec/exec.go
+func (w *prefixSuffixSaver) Bytes() []byte {
+	if w.suffix == nil {
+		return w.prefix
+	}
+	if w.skipped == 0 {
+		return append(w.prefix, w.suffix...)
+	}
+	var buf bytes.Buffer
+	buf.Grow(len(w.prefix) + len(w.suffix) + 50)
+	buf.Write(w.prefix)
+	buf.WriteString("\n... omitting ")
+	buf.WriteString(strconv.FormatInt(w.skipped, 10))
+	buf.WriteString(" bytes ...\n")
+	buf.Write(w.suffix[w.suffixOff:])
+	buf.Write(w.suffix[:w.suffixOff])
+	return buf.Bytes()
+}
+
+// Taken from exec/exec.go
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/exec.go
+++ b/exec.go
@@ -232,6 +232,8 @@ func (c *Cmd) Output() ([]byte, error) {
 
 // CombinedOutput runs the command and returns its combined standard
 // output and standard error.
+//
+// Taken from exec/exec.go.
 func (c *Cmd) CombinedOutput() ([]byte, error) {
 	if c.Stdout != nil {
 		return nil, errors.New("wsl: Stdout already set")
@@ -471,6 +473,7 @@ type prefixSuffixSaver struct {
 	// now just for error messages. It's only ~64KB anyway.
 }
 
+// Taken from exec/exec.go.
 func (w *prefixSuffixSaver) Write(p []byte) (n int, err error) {
 	lenp := len(p)
 	p = w.fill(&w.prefix, p)

--- a/exec.go
+++ b/exec.go
@@ -118,7 +118,7 @@ func (c *Cmd) Start() (err error) {
 		return fmt.Errorf("failed to convert command '%s' to UTF16", c.command)
 	}
 
-	var useCwd wBOOL = 0
+	var useCwd wBOOL
 	if c.UseCWD {
 		useCwd = 1
 	}
@@ -240,7 +240,7 @@ func (c *Cmd) closeDescriptors(closers []io.Closer) {
 	}
 }
 
-// Adapted from exec/exec.go
+// Adapted from exec/exec.go.
 func (c *Cmd) writerDescriptor(writer io.Writer) (f *os.File, err error) {
 	if writer == nil {
 		f, err = os.OpenFile(os.DevNull, os.O_WRONLY, 0)

--- a/exec.go
+++ b/exec.go
@@ -91,14 +91,14 @@ func (d *Distro) Command(ctx context.Context, cmd string) *Cmd {
 // once the command exits.
 func (c *Cmd) Start() (err error) {
 	defer func() {
-		if err != nil {
-			err = fmt.Errorf("error in distro %q during Start: %v", c.distro.Name, err)
+		if err == nil {
+			return
+		}
+		err = fmt.Errorf("wsl: %v", err)
+		if c.handle == 0 {
+			return
 		}
 	}()
-
-	if c.handle != 0 {
-		return errors.New("already started")
-	}
 
 	distroUTF16, err := syscall.UTF16PtrFromString(c.distro.Name)
 	if err != nil {
@@ -113,6 +113,10 @@ func (c *Cmd) Start() (err error) {
 	var useCwd wBOOL = 0
 	if c.UseCWD {
 		useCwd = 1
+	}
+
+	if c.handle != 0 {
+		return errors.New("already started")
 	}
 
 	if c.ctx != nil {

--- a/exec_test.go
+++ b/exec_test.go
@@ -305,5 +305,4 @@ func TestOutPipes(t *testing.T) {
 			require.Equal(t, tc.expectRead, buff.String())
 		})
 	}
-
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -173,7 +173,7 @@ func TestCommandStartWait(t *testing.T) {
 		case AfterWait:
 			return "AfterWait"
 		}
-		return "UNKNOWN_TIME"
+		return "UnknownTime"
 	}
 
 	type testCase struct {

--- a/exec_test.go
+++ b/exec_test.go
@@ -179,10 +179,11 @@ func TestCommandStartWait(t *testing.T) {
 	type testCase struct {
 		distro     *wsl.Distro
 		cmd        string
-		cancelOn   when
-		timeout    time.Duration
 		stdoutPipe bool
 		stderrPipe bool
+
+		cancelOn when
+		timeout  time.Duration
 
 		wantStdout    string
 		wantStderr    string
@@ -340,9 +341,9 @@ func TestCommandOutPipes(t *testing.T) {
 	d := newTestDistro(t, jammyRootFs)
 
 	testCases := map[string]struct {
+		cmd    string
 		stdout bool
 		stderr bool
-		cmd    string
 
 		wantRead string
 	}{
@@ -380,8 +381,8 @@ func TestCommandOutput(t *testing.T) {
 	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "--IHaveA\x00NullChar!"}
 
 	testCases := map[string]struct {
-		cmd          string
 		distro       *wsl.Distro
+		cmd          string
 		presetStdout io.Writer
 
 		wantStdout      string
@@ -391,14 +392,14 @@ func TestCommandOutput(t *testing.T) {
 		wantExitCode uint32
 		wantStderr   string
 	}{
-		"happy path":                                   {cmd: "exit 0", distro: &realDistro},
-		"happy path with stdout":                       {cmd: "echo Hello", distro: &realDistro, wantStdout: "Hello\n"},
-		"unregistered distro":                          {cmd: "exit 0", distro: &fakeDistro, errorWanted: true},
-		"null char in distro name":                     {cmd: "exit 0", distro: &wrongDistro, errorWanted: true},
-		"non-zero return value":                        {cmd: "exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
-		"non-zero return value with stderr":            {cmd: "echo 'Error!' >&2 && exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStderr: "Error!\n"},
-		"non-zero return value with stdout and stderr": {cmd: "echo Hello && echo 'Error!' >&2 && exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStdout: "Hello\n", wantStderr: "Error!\n"},
-		"error stdout already set":                     {cmd: "exit 0", distro: &realDistro, presetStdout: os.Stdout, errorWanted: true},
+		"happy path":                                   {distro: &realDistro, cmd: "exit 0"},
+		"happy path with stdout":                       {distro: &realDistro, cmd: "echo Hello", wantStdout: "Hello\n"},
+		"unregistered distro":                          {distro: &fakeDistro, cmd: "exit 0", errorWanted: true},
+		"null char in distro name":                     {distro: &wrongDistro, cmd: "exit 0", errorWanted: true},
+		"non-zero return value":                        {distro: &realDistro, cmd: "exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
+		"non-zero return value with stderr":            {distro: &realDistro, cmd: "echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStderr: "Error!\n"},
+		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStdout: "Hello\n", wantStderr: "Error!\n"},
+		"error stdout already set":                     {distro: &realDistro, cmd: "exit 0", presetStdout: os.Stdout, errorWanted: true},
 	}
 
 	for name, tc := range testCases {
@@ -438,8 +439,8 @@ func TestCommandCombinedOutput(t *testing.T) {
 	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "--IHaveA\x00NullChar!"}
 
 	testCases := map[string]struct {
-		cmd          string
 		distro       *wsl.Distro
+		cmd          string
 		presetStdout io.Writer
 		presetStderr io.Writer
 
@@ -449,15 +450,15 @@ func TestCommandCombinedOutput(t *testing.T) {
 		// Only relevant if wantExitError==true
 		wantExitCode uint32
 	}{
-		"happy path":                                   {cmd: "exit 0", distro: &realDistro},
-		"happy path with stdout":                       {cmd: "echo Hello", distro: &realDistro, wantOutput: "Hello\n"},
-		"unregistered distro":                          {cmd: "exit 0", distro: &fakeDistro, errorWanted: true},
-		"null char in distro name":                     {cmd: "exit 0", distro: &wrongDistro, errorWanted: true},
-		"non-zero return value":                        {cmd: "exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
-		"non-zero return value with stderr":            {cmd: "echo 'Error!' >&2 && exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Error!\n"},
-		"non-zero return value with stdout and stderr": {cmd: "echo Hello && echo 'Error!' >&2 && exit 42", distro: &realDistro, errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Hello\nError!\n"},
-		"error stdout already set":                     {cmd: "exit 0", distro: &realDistro, presetStdout: os.Stdout, errorWanted: true},
-		"error stderr already set":                     {cmd: "exit 0", distro: &realDistro, presetStderr: os.Stderr, errorWanted: true},
+		"happy path":                                   {distro: &realDistro, cmd: "exit 0"},
+		"happy path with stdout":                       {distro: &realDistro, cmd: "echo Hello", wantOutput: "Hello\n"},
+		"unregistered distro":                          {distro: &fakeDistro, cmd: "exit 0", errorWanted: true},
+		"null char in distro name":                     {distro: &wrongDistro, cmd: "exit 0", errorWanted: true},
+		"non-zero return value":                        {distro: &realDistro, cmd: "exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
+		"non-zero return value with stderr":            {distro: &realDistro, cmd: "echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Error!\n"},
+		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Hello\nError!\n"},
+		"error stdout already set":                     {distro: &realDistro, cmd: "exit 0", presetStdout: os.Stdout, errorWanted: true},
+		"error stderr already set":                     {distro: &realDistro, cmd: "exit 0", presetStderr: os.Stderr, errorWanted: true},
 	}
 
 	for name, tc := range testCases {

--- a/exec_test.go
+++ b/exec_test.go
@@ -356,7 +356,7 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >& 2")
+			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >&2")
 
 			var buff bytes.Buffer
 			if tc.stdout {

--- a/exec_test.go
+++ b/exec_test.go
@@ -356,7 +356,7 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && echo 'Hello stderr' >&2")
+			cmd := d.Command(context.Background(), "echo 'Hello stdout' >& 1 && sleep 1 && echo 'Hello stderr' >& 2")
 
 			var buff bytes.Buffer
 			if tc.stdout {

--- a/exec_test.go
+++ b/exec_test.go
@@ -203,12 +203,12 @@ func TestCommandStartWait(t *testing.T) {
 		"success with stdout":       {distro: &realDistro, cmd: "echo 'Hello!'", stdoutPipe: true, wantStdout: "Hello!\n"},
 		"success with empty stderr": {distro: &realDistro, cmd: "exit 0", stdoutPipe: true},
 		"success with stderr":       {distro: &realDistro, cmd: "echo 'Error!' 1>&2", stderrPipe: true, wantStderr: "Error!\n"},
-		"success with both pipes":   {distro: &realDistro, cmd: "echo 'Hello!' && echo 'Error!' 1>&2", stdoutPipe: true, wantStdout: "Hello!\n", stderrPipe: true, wantStderr: "Error!\n"},
+		"success with both pipes":   {distro: &realDistro, cmd: "echo 'Hello!' && sleep 1 && echo 'Error!' 1>&2", stdoutPipe: true, wantStdout: "Hello!\n", stderrPipe: true, wantStderr: "Error!\n"},
 
 		// Pipe failure
-		"failure exit code with stdout": {distro: &realDistro, cmd: "echo 'Hello!' && echo 'Error!' 1>&2 && exit 42", stdoutPipe: true, wantStdout: "Hello!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
-		"failure exit code with stderr": {distro: &realDistro, cmd: "echo 'Hello!' && echo 'Error!' 1>&2 && exit 42", stderrPipe: true, wantStderr: "Error!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
-		"failure exit code both pipes":  {distro: &realDistro, cmd: "echo 'Hello!' && echo 'Error!' 1>&2 && exit 42", stdoutPipe: true, wantStdout: "Hello!\n", stderrPipe: true, wantStderr: "Error!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
+		"failure exit code with stdout": {distro: &realDistro, cmd: "echo 'Hello!' && sleep 1 && echo 'Error!' 1>&2 && exit 42", stdoutPipe: true, wantStdout: "Hello!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
+		"failure exit code with stderr": {distro: &realDistro, cmd: "echo 'Hello!' && sleep 1 && echo 'Error!' 1>&2 && exit 42", stderrPipe: true, wantStderr: "Error!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
+		"failure exit code both pipes":  {distro: &realDistro, cmd: "echo 'Hello!' && sleep 1 && echo 'Error!' 1>&2 && exit 42", stdoutPipe: true, wantStdout: "Hello!\n", stderrPipe: true, wantStderr: "Error!\n", wantErrOn: AfterWait, wantExitError: &wsl.ExitError{Code: 42}},
 
 		// Timeout context
 		"timeout success":          {distro: &realDistro, cmd: "exit 0", timeout: 2 * time.Second},
@@ -398,7 +398,7 @@ func TestCommandOutput(t *testing.T) {
 		"null char in distro name":                     {distro: &wrongDistro, cmd: "exit 0", errorWanted: true},
 		"non-zero return value":                        {distro: &realDistro, cmd: "exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
 		"non-zero return value with stderr":            {distro: &realDistro, cmd: "echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStderr: "Error!\n"},
-		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStdout: "Hello\n", wantStderr: "Error!\n"},
+		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && sleep 1 && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantStdout: "Hello\n", wantStderr: "Error!\n"},
 		"error stdout already set":                     {distro: &realDistro, cmd: "exit 0", presetStdout: os.Stdout, errorWanted: true},
 	}
 
@@ -456,7 +456,7 @@ func TestCommandCombinedOutput(t *testing.T) {
 		"null char in distro name":                     {distro: &wrongDistro, cmd: "exit 0", errorWanted: true},
 		"non-zero return value":                        {distro: &realDistro, cmd: "exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42},
 		"non-zero return value with stderr":            {distro: &realDistro, cmd: "echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Error!\n"},
-		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Hello\nError!\n"},
+		"non-zero return value with stdout and stderr": {distro: &realDistro, cmd: "echo Hello && sleep 1 && echo 'Error!' >&2 && exit 42", errorWanted: true, exitErrorWanted: true, wantExitCode: 42, wantOutput: "Hello\nError!\n"},
 		"error stdout already set":                     {distro: &realDistro, cmd: "exit 0", presetStdout: os.Stdout, errorWanted: true},
 		"error stderr already set":                     {distro: &realDistro, cmd: "exit 0", presetStderr: os.Stderr, errorWanted: true},
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -263,7 +263,7 @@ func TestCommandStartWait(t *testing.T) {
 
 			cmd := tc.distro.Command(ctx, tc.cmd)
 
-			// BEFORE_START block
+			// BeforeStart block
 			if tc.cancelOn == BeforeStart {
 				cancel()
 			}
@@ -291,7 +291,7 @@ func TestCommandStartWait(t *testing.T) {
 			cmd.Stdin = 0
 			err = cmd.Start()
 
-			// AFTER_START block
+			// AfterStart block
 			if tc.cancelOn == AfterStart {
 				cancel()
 			}
@@ -326,7 +326,7 @@ func TestCommandStartWait(t *testing.T) {
 
 			err = cmd.Wait()
 
-			// AFTER_WAIT block
+			// AfterWait block
 			if requireErrors(t, tc, AfterWait, err) {
 				return
 			}

--- a/exec_test.go
+++ b/exec_test.go
@@ -355,7 +355,7 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			cmd := d.Command(context.Background(), "echo 'Hello stdout' >& 1 && echo 'Hello stderr' >& 2")
+			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && echo 'Hello stderr' >&2")
 
 			var buff bytes.Buffer
 			if tc.stdout {

--- a/exec_test.go
+++ b/exec_test.go
@@ -73,9 +73,10 @@ func TestCommandRun(t *testing.T) {
 		wantErr       bool
 		wantExitError *wsl.ExitError
 	}{
-		"success":       {cmd: "exit 0"},
-		"windows error": {cmd: "exit 0", fakeDistro: true, wantErr: true},
-		"linux error":   {cmd: "exit 42", wantErr: true, wantExitError: &wsl.ExitError{Code: 42}},
+		"success":                      {cmd: "exit 0"},
+		"windows error":                {cmd: "exit 0", fakeDistro: true, wantErr: true},
+		"linux error":                  {cmd: "exit 42", wantErr: true, wantExitError: &wsl.ExitError{Code: 42}},
+		"command with null char error": {cmd: "echo \x00", fakeDistro: true, wantErr: true},
 
 		// timeout cases
 		"success with timeout long enough":       {cmd: "exit 0", timeout: 6 * time.Second},

--- a/exec_test.go
+++ b/exec_test.go
@@ -355,7 +355,7 @@ func TestCommandOutput(t *testing.T) {
 			require.ErrorIsf(t, err, wsl.ExitError{}, "Unexpected error type. Expected an ExitCode.")
 			require.Equal(t, err.(*wsl.ExitError).Code, tc.wantExitCode, "Unexpected value for ExitError.Code.") // nolint: forcetypeassert, errorlint
 
-			require.Equal(t, tc.wantStderr, string(err.(*wsl.ExitError).Stderr), "Unexpected contents in stderr")
+			require.Equal(t, tc.wantStderr, string(err.(*wsl.ExitError).Stderr), "Unexpected contents in stderr") // nolint: forcetypeassert, errorlint
 		})
 	}
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -162,13 +162,13 @@ func TestCommandStartWait(t *testing.T) {
 	whenToString := func(w when) string {
 		switch w {
 		case Never:
-			return "NEVER"
+			return "Never"
 		case BeforeStart:
-			return "BEFORE_START"
+			return "BeforeStart"
 		case AfterStart:
-			return "AFTER_START"
+			return "AfterStart"
 		case AfterWait:
-			return "AFTER_WAIT"
+			return "AfterWait"
 		}
 		return "UNKNOWN_TIME"
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -356,7 +356,7 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			cmd := d.Command(context.Background(), "echo 'Hello stdout' >& 1 && sleep 1 && echo 'Hello stderr' >& 2")
+			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >& 2")
 
 			var buff bytes.Buffer
 			if tc.stdout {

--- a/exec_test.go
+++ b/exec_test.go
@@ -367,9 +367,8 @@ func TestCommandOutPipes(t *testing.T) {
 			}
 
 			err := cmd.Run()
-			require.NoError(t, err, "Did not expect an error when launching command")
+			require.NoError(t, err, "Did not expect an error during (*Cmd).Run")
 
-			require.NoError(t, err, "Did not expect read from pipe to return an error")
 			require.Equal(t, tc.wantRead, buff.String())
 		})
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -49,7 +49,6 @@ func TestCommandRun(t *testing.T) {
 
 	// Poking distro to wake it up
 	cmd := realDistro.Command(context.Background(), "exit 0")
-	cmd.Stdout = 0
 	cmd.Stderr = 0
 	err := cmd.Run()
 	require.NoError(t, err)
@@ -113,7 +112,6 @@ func TestCommandRun(t *testing.T) {
 			}
 
 			cmd := d.Command(ctx, tc.cmd)
-			cmd.Stdout = 0
 			cmd.Stderr = 0
 
 			switch tc.cancelOn {
@@ -254,7 +252,6 @@ func TestCommandStartWait(t *testing.T) {
 
 			cmd.Stdin = 0
 			cmd.Stderr = 0
-			cmd.Stdout = 0
 			err := cmd.Start()
 
 			// AFTER_START block
@@ -264,6 +261,9 @@ func TestCommandStartWait(t *testing.T) {
 			if requireErrors(t, tc, AfterStart, err) {
 				return
 			}
+
+			err = cmd.Start()
+			require.Error(t, err, "Unexpectedly succeeded at starting a command that had already been started")
 
 			err = cmd.Wait()
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -286,7 +286,7 @@ func TestCommandStartWait(t *testing.T) {
 			}
 
 			err := cmd.Wait()
-			require.Error(t, err, "Unexpected success calling (*Cmd).Wait before (*Cmd).Wait")
+			require.Error(t, err, "Unexpected success calling (*Cmd).Wait before (*Cmd).Start")
 
 			cmd.Stdin = 0
 			err = cmd.Start()
@@ -316,7 +316,7 @@ func TestCommandStartWait(t *testing.T) {
 			}
 
 			err = cmd.Start()
-			require.Error(t, err, "Unexpected succeeded calling (*Cmd).Start twice")
+			require.Error(t, err, "Unexpected success calling (*Cmd).Start twice")
 
 			_, err = cmd.StdoutPipe()
 			require.Error(t, err, "Unexpected success calling (*Cmd).StdoutPipe after (*Cmd).Start")
@@ -332,7 +332,7 @@ func TestCommandStartWait(t *testing.T) {
 			}
 
 			err = cmd.Wait()
-			require.Error(t, err, "Unexpected succeeded calling (*Cmd).Wait twice")
+			require.Error(t, err, "Unexpected success calling (*Cmd).Wait twice")
 		})
 	}
 }


### PR DESCRIPTION
Implements the following methods with the same API as `exec/exec.go` (and often the same implementation):
```go
var Cmd.Stdout io.Writer
var Cmd.Stderr io.Writer
func (c *Cmd) Output() ([]byte, error)
func (c *Cmd) CombinedOutput() ([]byte, error)
func (c *Cmd) StdoutPipe() (io.ReadCloser, error)
func (c *Cmd) StderrPipe() (io.ReadCloser, error)

// This private struct is used by Output() and exposes a 
// couple public methods to implement the io.Writer interface.
type prefixSuffixSaver struct 
func (w *prefixSuffixSaver) Write(p []byte) (n int, err error)
func (w *prefixSuffixSaver) Bytes() []byte
```