### PR TITLE
Added words "Windows Subsystem for Linux" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module ofers an idiomatic interface between your Go code and the Windows Su
 We aim not to extend the aforementioned API, but rather to provide a safe, idomatic, and easy-to-use wrapper around it. The goal is to enable the development of applications that build on top of it. 
 
 ## Requirements
-- WSL must be installed ([documentation](https://learn.microsoft.com/en-us/windows/wsl/install)) and enabled.
+- Windows Subsystem for Linux must be installed ([documentation](https://learn.microsoft.com/en-us/windows/wsl/install)) and enabled.
 - Go version must be equal to or above 1.18.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GoWSL
-This module ofers an idiomatic interface between your Go code and the WSL API (`wslApi.dll`  and ocasionally `wsl.exe`). It offers wrappers around common actions to manage WSL distros. 
+This module ofers an idiomatic interface between your Go code and the Windows Subsystem for Linux (WSL) API (`wslApi.dll`  and ocasionally `wsl.exe`). It offers wrappers around common actions to manage WSL distros. 
 
 ## Aim
 We aim not to extend the aforementioned API, but rather to provide a safe, idomatic, and easy-to-use wrapper around it. The goal is to enable the development of applications that build on top of it. 


### PR DESCRIPTION
I was reading the README and noticed we only refered to this component as WSL. There is no mention of the words "Windows Subsystem for Linux" anywhere on the repo which can be confusing to users discovering this out of context.

This fixes it.