### PR TITLE
Fixed various issues in main_test.go

### DIFF
--- a/distro_test.go
+++ b/distro_test.go
@@ -74,8 +74,8 @@ func isTestLinuxProcessAlive(d *wsl.Distro) bool {
 
 func TestDistroString(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
-	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "_\x00_invalid_name"}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
+	wrongDistro := wsl.Distro{Name: uniqueDistroName(t) + "_\x00_invalid_name"}
 
 	testCases := map[string]struct {
 		distro     *wsl.Distro
@@ -205,7 +205,7 @@ func TestConfigurationSetters(t *testing.T) {
 				err := d.Command(context.Background(), "useradd testuser").Run()
 				require.NoError(t, err, "unexpectedly failed to add a user to the distro")
 			case DistroNotRegistered:
-				d = wsl.Distro{Name: UniqueDistroName(t)}
+				d = wsl.Distro{Name: uniqueDistroName(t)}
 			case DistroInvalidName:
 				d = wsl.Distro{Name: "Wrong character \x00 in name"}
 			}

--- a/exec_test.go
+++ b/exec_test.go
@@ -49,7 +49,7 @@ func TestExitErrorAsString(t *testing.T) {
 
 func TestCommandRun(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
 
 	// Poking distro to wake it up
 	err := realDistro.Command(context.Background(), "exit 0").Run()
@@ -150,8 +150,8 @@ func TestCommandRun(t *testing.T) {
 
 func TestCommandStartWait(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
-	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "--IHaveA\x00NullChar!"}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
+	wrongDistro := wsl.Distro{Name: uniqueDistroName(t) + "--IHaveA\x00NullChar!"}
 
 	// Enum with various times in the execution
 	type when uint
@@ -375,8 +375,8 @@ func TestCommandOutPipes(t *testing.T) {
 
 func TestCommandOutput(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
-	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "--IHaveA\x00NullChar!"}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
+	wrongDistro := wsl.Distro{Name: uniqueDistroName(t) + "--IHaveA\x00NullChar!"}
 
 	testCases := map[string]struct {
 		distro       *wsl.Distro
@@ -434,8 +434,8 @@ func TestCommandOutput(t *testing.T) {
 
 func TestCommandCombinedOutput(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
-	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "--IHaveA\x00NullChar!"}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
+	wrongDistro := wsl.Distro{Name: uniqueDistroName(t) + "--IHaveA\x00NullChar!"}
 
 	testCases := map[string]struct {
 		distro       *wsl.Distro

--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,7 @@ func sanitizeDistroName(candidateName string) string {
 }
 
 // Generates a unique distro name. It does not create the distro.
-func UniqueDistroName(t *testing.T) string {
+func uniqueDistroName(t *testing.T) string {
 	t.Helper()
 	maxAttempts := 10
 	for i := 0; i < maxAttempts; i++ {

--- a/main_test.go
+++ b/main_test.go
@@ -55,7 +55,7 @@ func sanitizeDistroName(candidateName string) string {
 // Generates a unique distro name. It does not create the distro.
 func uniqueDistroName(t *testing.T) string {
 	t.Helper()
-	maxAttempts := 10
+	const maxAttempts = 10
 	for i := 0; i < maxAttempts; i++ {
 		d := wsl.Distro{Name: sanitizeDistroName(fmt.Sprintf("%s_%s_%s", namePrefix, t.Name(), uniqueID()))}
 		// Ensuring no name collision
@@ -65,7 +65,7 @@ func uniqueDistroName(t *testing.T) string {
 			continue
 		}
 		if exists {
-			t.Logf("Setup: name collision generating test distro: %q", d.Name)
+			t.Logf("Setup: name collision generating test distro: %q.", d.Name)
 			continue
 		}
 		return d.Name

--- a/main_test.go
+++ b/main_test.go
@@ -66,6 +66,7 @@ func uniqueDistroName(t *testing.T) string {
 		}
 		if exists {
 			t.Logf("Setup: name collision generating test distro: %q", d.Name)
+			continue
 		}
 		return d.Name
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -84,7 +84,7 @@ func newTestDistro(t *testing.T, rootfs string) wsl.Distro {
 	powershellInstallDistro(t, d.Name, rootfs)
 
 	t.Cleanup(func() {
-		err := CleanUpWslInstance(d)
+		err := cleanUpWslInstance(d)
 		if err != nil {
 			t.Logf("Cleanup: %v\n", err)
 		}
@@ -157,15 +157,15 @@ func cleanUpTestWslInstances() {
 	}
 
 	for _, d := range testInstances {
-		err := CleanUpWslInstance(d)
+		err := cleanUpWslInstance(d)
 		if err != nil {
 			log.Warnf("Cleanup: %v\n", err)
 		}
 	}
 }
 
-// CleanUpWslInstance checks if a distro exists and if it does, it unregisters it.
-func CleanUpWslInstance(distro wsl.Distro) error {
+// cleanUpWslInstance checks if a distro exists and if it does, it unregisters it.
+func cleanUpWslInstance(distro wsl.Distro) error {
 	if r, err := distro.IsRegistered(); err == nil && !r {
 		return nil
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -61,15 +61,15 @@ func uniqueDistroName(t *testing.T) string {
 		// Ensuring no name collision
 		exists, err := d.IsRegistered()
 		if err != nil {
-			t.Logf("Setup: Generated invalid distro name: %q. Trying again.", d.Name)
+			t.Logf("Setup: error in test distro name uniqueness check: %v", err)
 			continue
 		}
 		if exists {
-			t.Logf("Setup: Generated non-unique distro name: %q. Trying again.", d.Name)
+			t.Logf("Setup: name collision generating test distro: %q", d.Name)
 		}
 		return d.Name
 	}
-	require.Fail(t, "Setup: Failed to generate a valid, unique distro name.")
+	require.Fail(t, "Setup: failed to generate a unique name for the test distro.")
 	return ""
 }
 
@@ -77,7 +77,7 @@ func uniqueDistroName(t *testing.T) string {
 func newTestDistro(t *testing.T, rootfs string) wsl.Distro {
 	t.Helper()
 
-	d := wsl.Distro{Name: UniqueDistroName(t)}
+	d := wsl.Distro{Name: uniqueDistroName(t)}
 	t.Logf("Setup: Registering %q\n", d.Name)
 
 	powershellInstallDistro(t, d.Name, rootfs)

--- a/registration_test.go
+++ b/registration_test.go
@@ -27,7 +27,7 @@ func TestRegister(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			d := wsl.Distro{Name: uniqueDistroName(t) + tc.distroSuffix}
 			defer func() {
-				err := CleanUpWslInstance(d)
+				err := cleanUpWslInstance(d)
 				if err != nil {
 					t.Logf("Cleanup: %v", err)
 				}

--- a/registration_test.go
+++ b/registration_test.go
@@ -25,7 +25,7 @@ func TestRegister(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			d := wsl.Distro{Name: UniqueDistroName(t) + tc.distroSuffix}
+			d := wsl.Distro{Name: uniqueDistroName(t) + tc.distroSuffix}
 			defer func() {
 				err := CleanUpWslInstance(d)
 				if err != nil {
@@ -63,7 +63,7 @@ func TestRegister(t *testing.T) {
 func TestRegisteredDistros(t *testing.T) {
 	d1 := newTestDistro(t, emptyRootFs)
 	d2 := newTestDistro(t, emptyRootFs)
-	d3 := wsl.Distro{Name: UniqueDistroName(t)}
+	d3 := wsl.Distro{Name: uniqueDistroName(t)}
 
 	list, err := wsl.RegisteredDistros()
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestIsRegistered(t *testing.T) {
 			if config.register {
 				distro = newTestDistro(t, emptyRootFs)
 			} else {
-				distro = wsl.Distro{Name: UniqueDistroName(t)}
+				distro = wsl.Distro{Name: uniqueDistroName(t)}
 			}
 
 			reg, err := distro.IsRegistered()
@@ -115,8 +115,8 @@ func TestIsRegistered(t *testing.T) {
 
 func TestUnregister(t *testing.T) {
 	realDistro := newTestDistro(t, emptyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
-	wrongDistro := wsl.Distro{Name: UniqueDistroName(t) + "This Distro \x00 has a null char"}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
+	wrongDistro := wsl.Distro{Name: uniqueDistroName(t) + "This Distro \x00 has a null char"}
 
 	testCases := map[string]struct {
 		distro    *wsl.Distro

--- a/shell_test.go
+++ b/shell_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestShell(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
-	fakeDistro := wsl.Distro{Name: UniqueDistroName(t)}
+	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
 	wrongDistro := wsl.Distro{Name: "I have a \x00 null char in my name"}
 
 	cmdExit0 := "exit 0"


### PR DESCRIPTION
Started as a gardening operation but I found a couple bigger issues:

- `UniqueDistroName` and `CleanUpWslInstance`: These two functions were public and untested. Unless we decide to spin off a proper wsl testing module, it is my opinion that these should stay private.
- `UniqueDistroName` had a bug were name collisions were reported but allowed, potentially causing non-deterministic test coupling issues.

The actual gardening:
- Improved `UniqueDistroName` error and log messages.