### PR TITLE
Go.mod fixes

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 // This file contains windows-only API definitions and imports
 

--- a/distro.go
+++ b/distro.go
@@ -1,8 +1,8 @@
-// Package wsl wraps around the wslApi.dll (and sometimes wsl.exe) for
+// Package GoWSL wraps around the wslApi.dll (and sometimes wsl.exe) for
 // safe and idiomatic use within Go projects.
 //
 // This package is not thread safe.
-package wsl
+package GoWSL
 
 // This file contains utilities to interact with a Distro and its configuration
 

--- a/distro_test.go
+++ b/distro_test.go
@@ -1,12 +1,13 @@
-package wsl_test
+package GoWSL_test
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"context"
 	"fmt"
 	"os/exec"
 	"testing"
 	"time"
-	"wsl"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"context"
 	"errors"
 	"fmt"
 	"time"
-	"wsl"
 )
 
 func main() {

--- a/exec.go
+++ b/exec.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 // This file contains utilities to launch commands into WSL distros.
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,6 +1,8 @@
-package wsl_test
+package GoWSL_test
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"bufio"
 	"bytes"
 	"context"
@@ -10,7 +12,6 @@ import (
 	"os"
 	"testing"
 	"time"
-	"wsl"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module wsl
+module github.com/EduardGomezEscandell/GoWSL
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require golang.org/x/sys v0.1.0
 
 require (
-	github.com/0xrawsec/golang-utils v1.3.2 // indirect
+	github.com/0xrawsec/golang-utils v1.3.2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
+	github.com/stretchr/testify v1.8.1
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal_test.go
+++ b/internal_test.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 import (
 	"fmt"

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,10 @@
-package wsl_test
+package GoWSL_test
 
 // This file contains testing functionality
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"bufio"
 	"bytes"
 	"context"
@@ -14,7 +16,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"wsl"
 
 	"github.com/0xrawsec/golang-utils/log"
 	"github.com/stretchr/testify/require"

--- a/registration.go
+++ b/registration.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 // This file contains utilities to create, destroy, stop WSL distros,
 // as well as utilities to query this status.

--- a/registration_test.go
+++ b/registration_test.go
@@ -1,9 +1,10 @@
-package wsl_test
+package GoWSL_test
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"testing"
 	"time"
-	"wsl"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/shell.go
+++ b/shell.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 import (
 	"errors"

--- a/shell_test.go
+++ b/shell_test.go
@@ -1,9 +1,10 @@
-package wsl_test
+package GoWSL_test
 
 import (
+	wsl "github.com/EduardGomezEscandell/GoWSL"
+
 	"testing"
 	"time"
-	"wsl"
 
 	"github.com/stretchr/testify/require"
 )

--- a/wslexe_windows.go
+++ b/wslexe_windows.go
@@ -1,4 +1,4 @@
-package wsl
+package GoWSL
 
 // This file contains utilities to access functionality often accessed via wsl.exe,
 // with the advantage (sometimes) of not needing to start a subprocess.


### PR DESCRIPTION
- Fix go.mod module path:
The module path needs to match the import path.
Unfortunately, that means that the module will be named "GoWSL" in applications using it.
This is to be able to generated documentation on pkg.go.dev.
- Be more consistent on package name: we now rather rename the package at import time. While it’s possible to have package name which differs from import path, this is an antipattern. It’s better to be explicit.
- Also, use the fqdn part for the import in tests as go modules prefers this over relative ones.
- Use this opportunity to import at the top the package we are testing against.
- Fix some imported module attribute stenza:
Imported module should not be marked as indirectly imported. They are direct imports.
