### PR TITLE
feat: Adds the hostname command to the translation table

### DIFF
--- a/mock/command.go
+++ b/mock/command.go
@@ -66,6 +66,7 @@ var translateCommand = map[string]mockedCommand{
 
 	// Other
 	"useradd testuser": {linux: "exit 0", windows: "EXIT 0"},
+	"hostname":         {linux: "hostname", windows: "hostname"},
 }
 
 // newCommandProcess starts a process of type:


### PR DESCRIPTION
(reopening because I merged on top of the wrong branch 🙈 )

In the GoWSL mock.
That's needed in some test code outside of this repo.
I have this in an ongoing PR in UP4W and need this fix to move forward:

```
--- FAIL: TestDatabaseGetUnmanaged (0.00s)
    --- FAIL: TestDatabaseGetUnmanaged/empty_database (0.00s)
panic: WslLaunch command not supported: hostname [recovered]
	panic: WslLaunch command not supported: hostname
	

goroutine 21 [running]:
testing.tRunner.func1.2({0xd84d40, 0xc000332480})
	/usr/lib/go-1.24/src/testing/testing.go:1734 +0x3eb
testing.tRunner.func1()
	/usr/lib/go-1.24/src/testing/testing.go:1737 +0x696
panic({0xd84d40?, 0xc000332480?})
	/usr/lib/go-1.24/src/runtime/panic.go:792 +0x132
github.com/ubuntu/gowsl/mock.newMockedCommand({0xe862d3, 0x8})
	/home/.../go/pkg/mod/github.com/ubuntu/gowsl@v0.0.0-20250220202122-f4267f82434b/mock/command.go:34 +0x165
github.com/ubuntu/gowsl/mock.(*Backend).WslLaunch...
```